### PR TITLE
Fix NDEV-13369 ignore initcontainers if absent

### DIFF
--- a/best-practices/require-drop-all-capabilities.yaml
+++ b/best-practices/require-drop-all-capabilities.yaml
@@ -16,7 +16,7 @@ spec:
         kinds:
         - Pod
     validate:
-      message: "All capabilities should be dropped with only those required added back."
+      message: "All capabilities should be dropped with only those required added back. The capabilities.drop[] field must specify only ALL and no others."
       pattern:
         spec:
           containers:
@@ -24,6 +24,6 @@ spec:
               capabilities:
                 drop: ["ALL"]
           =(initContainers):
-          - =(securityContext):
-              (capabilities):
+          - securityContext:
+              capabilities:
                 drop: ["ALL"]

--- a/best-practices/require-drop-all-capabilities.yaml
+++ b/best-practices/require-drop-all-capabilities.yaml
@@ -23,16 +23,7 @@ spec:
           - securityContext:
               capabilities:
                 drop: ["ALL"]
-  - name: check-init-containers
-    match:
-      resources:
-        kinds:
-        - Pod
-    validate:
-      message: "All capabilities should be dropped with only those required added back."
-      pattern:
-        spec:
-          initContainers:
-          - securityContext:
-              capabilities:
+          =(initContainers):
+          - =(securityContext):
+              (capabilities):
                 drop: ["ALL"]


### PR DESCRIPTION
This idea has been taken from PR https://github.com/kyverno/policies/pull/36/files#diff-4175f01649a3eae8f6dfb0ce0bc626cf3ab10f76953a073ecb7a7f03c5427c32

Tested the new version of the policy against the test suite at: https://github.com/kyverno/policies/tree/main/pod-security/restricted/disallow-capabilities-strict. 6 cases did fail, namely, goodpod2, goodpod5, gooddeployment2, gooddeployment5, goodcronjob2, goodcronjob5. But the failures are very uncommon scenarios (multiple elements in the drop array). 

After this merge, customers need to upgrade their policy group v3.1 version to this latest commit.

In versions 1.6.0+, we can use the new way to achieve our objective.
See https://kyverno.io/policies/best-practices/require_drop_all/require_drop_all/
But since we have many customers using 1.5.8, and we don't have separate policy manifests
per Kyverno version, we will stick to the method used in this change, for some time.

