### PR TITLE
chore: refresh PSS policies with latest changes

### DIFF
--- a/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -38,7 +38,7 @@ spec:
                 all:
                 - key: ALL
                   operator: AnyNotIn
-                  value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || '[]' }}"
+                  value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
     - name: adding-capabilities-strict
       match:
         any:
@@ -58,7 +58,7 @@ spec:
             deny:
               conditions:
                 all:
-                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || '[]' }}"
+                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
                   operator: AnyNotIn
                   value:
                   - NET_BIND_SERVICE

--- a/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -25,7 +25,7 @@ spec:
               - Pod
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       validate:
@@ -38,7 +38,7 @@ spec:
                 all:
                 - key: ALL
                   operator: AnyNotIn
-                  value: "{{ element.securityContext.capabilities.drop || '' }}"
+                  value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || '[]' }}"
     - name: adding-capabilities-strict
       match:
         any:
@@ -47,7 +47,7 @@ spec:
               - Pod
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       validate:
@@ -58,7 +58,7 @@ spec:
             deny:
               conditions:
                 all:
-                - key: "{{ element.securityContext.capabilities.add[] || '' }}"
+                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || '[]' }}"
                   operator: AnyNotIn
                   value:
                   - NET_BIND_SERVICE


### PR DESCRIPTION
Signed-off-by: Pankaj Khushalani <pankaj.khushalani@nirmata.com>

Referring to the changes made in [PR#420](https://github.com/kyverno/policies/pull/420) and [PR#421](https://github.com/kyverno/policies/pull/421) of `kyverno/policies`, the PSS policy `pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml` required the following updates -

- Sending `drop[]` and `add[]` policies to `to_upper()` to be case insensitive
- Allowing policy to go in BACKGROUND mode if `request.operation` cannot be resolved

